### PR TITLE
Remove custom props from styled-component `shared/Button`

### DIFF
--- a/src/components/app-header/app-header.tsx
+++ b/src/components/app-header/app-header.tsx
@@ -20,7 +20,7 @@ export const AppHeader = () => {
           <NavigationBar />
         </UI.Column>
         <UI.Column>
-          <Button $variant="outline">Sign In</Button>
+          <Button className="outline">Sign In</Button>
           <Button>Sign Up</Button>
         </UI.Column>
       </UI.Center>

--- a/src/components/shared/button.tsx
+++ b/src/components/shared/button.tsx
@@ -1,9 +1,7 @@
-import { css, styled } from 'styled-components'
+import { styled } from 'styled-components'
 import { typography } from '~/styles'
 
-type variant = 'outline' | 'filled'
-
-export const Button = styled.button<{ $variant?: variant }>`
+export const Button = styled.button`
   ${typography['text-bold']}
   font-size: 14px;
   cursor: pointer;
@@ -22,11 +20,9 @@ export const Button = styled.button<{ $variant?: variant }>`
     color: #34aebc;
     transition: none;
   }
-  ${(props) =>
-    props.$variant === 'outline' &&
-    css`
-      border-color: transparent;
-    `}
+  &.outline {
+    border-color: transparent;
+  }
 `
 
 export const ButtonWide = styled(Button)`


### PR DESCRIPTION
For some reason, the custom properties used for styling in styled-components aren't functioning properly. However, basic styling using class names seems to work well.

Fixes #13 