### PR TITLE
Improve `when` filter format for better readability

### DIFF
--- a/cypress/e2e/home-page.cy.ts
+++ b/cypress/e2e/home-page.cy.ts
@@ -10,4 +10,12 @@ describe('Home Page', () => {
   it('should render loading message', () => {
     cy.contains('PLEASE WAIT').should('be.visible')
   })
+
+  it('should render "Where" filter with default value "Any region"', () => {
+    cy.contains('header', 'Any region').should('be.visible')
+  })
+
+  it('should render "Order" filter with default value "Relevance"', () => {
+    cy.contains('header', 'Relevance').should('be.visible')
+  })
 })

--- a/src/components/app-header/filter-input-area.styles.tsx
+++ b/src/components/app-header/filter-input-area.styles.tsx
@@ -40,9 +40,12 @@ export const InputArea = styled.div`
     }
   }
   /* mantine or native inputs */
+  &:last-child > label + div {
+    right: 2px;
+  }
   & > label + div {
     position: absolute;
-    inset: 2px;
+    inset: 2px 3px 2px 2px;
     display: flex;
     align-items: flex-end;
     padding: 0;

--- a/src/components/app-header/filters.tsx
+++ b/src/components/app-header/filters.tsx
@@ -8,12 +8,12 @@ import { FilterInputArea } from './filter-input-area'
 import { InputSelect } from '../shared/input-select'
 import { InputDateRange } from '../shared/input-date-range'
 import { InputText } from '../shared/input-text'
-import { convertToLocalDate, convertToSQLDate } from '~/lib/date'
+import { convertToSQLDate, formatRangePeriod } from '~/lib/date'
 
 const DEFAULT_REGION = 'Any region'
 
 const orderOptions = [
-  { value: 'RELEVANCE', label: 'Relevance' },
+  { value: 'RELEVANCE', label: 'Relevance', default: true },
   { value: 'PRICE_ASC', label: 'Lowest price first' },
   { value: 'PRICE_DESC', label: 'Highest price first' },
 ]
@@ -39,7 +39,8 @@ type BookingPeriod = {
 export const Filters = ({ initialRegionName }: { initialRegionName?: string }) => {
   const router = useRouter()
   const qs = useQueryStringContext()
-  const { checkIn, checkOut, guests, order } = qs.data
+  const { checkIn, checkOut, guests } = qs.data
+  const order = qs.data.order ?? orderOptions.find((i) => i.default)?.value
 
   function setBookingPeriod({ checkIn, checkOut }: BookingPeriod) {
     if (!checkIn === !checkOut) {
@@ -51,7 +52,7 @@ export const Filters = ({ initialRegionName }: { initialRegionName?: string }) =
   }
   const labelPeriod = useMemo(() => {
     if (checkIn && checkOut) {
-      return convertToLocalDate(checkIn) + ` - ` + convertToLocalDate(checkOut)
+      return formatRangePeriod(checkIn, checkOut)
     }
   }, [checkIn, checkOut])
 
@@ -124,6 +125,7 @@ export const Filters = ({ initialRegionName }: { initialRegionName?: string }) =
           <InputSelect
             name="order"
             data={orderOptions}
+            defaultValue={order}
             onChange={(value) => qs.addQueryString({ order: value })}
           />
         </FilterInputArea>

--- a/src/components/homes-not-found/homes-not-found.tsx
+++ b/src/components/homes-not-found/homes-not-found.tsx
@@ -2,6 +2,7 @@
 import imgSatellite from '~/assets/satellite.svg'
 import * as UI from './homes-not-found.styles'
 import { ButtonWide } from '../shared'
+import { Animation } from '../shared/animation'
 
 type Props = {
   pageCenter?: boolean
@@ -12,7 +13,9 @@ type Props = {
 export const HomesNotFound = ({ region, pageCenter, onClick }: Props) => {
   return (
     <UI.Wrapper className={pageCenter ? 'page-center' : undefined}>
-      <UI.AnimatedImage src={imgSatellite} alt="Satellite" />
+      <Animation.FadeIn>
+        <UI.AnimatedImage src={imgSatellite} alt="Satellite" />
+      </Animation.FadeIn>
       <p>Oops! We haven&apos;t found anything matching your search.</p>
       <p>Try something else or reset the filters to see all {region} homes.</p>
       <ButtonWide onClick={onClick}>See all {region} homes</ButtonWide>

--- a/src/components/shared/animation.tsx
+++ b/src/components/shared/animation.tsx
@@ -1,0 +1,19 @@
+'use client'
+import { keyframes, styled } from 'styled-components'
+
+export const Animation = {
+  FadeIn: ({ children }: { children: React.ReactNode }) => {
+    return <WrapperFadeIn>{children}</WrapperFadeIn>
+  },
+}
+
+const animFadeIn = keyframes`
+  from { opacity: 0.5; transform: translate(0, 10px) }
+  to { opacity: 1.0; transform: translate(0, 0) }
+`
+
+const WrapperFadeIn = styled.div`
+  opacity: 1;
+  animation: ${animFadeIn} 0.2s ease-in;
+  animation-iteration-count: 1;
+`

--- a/src/components/shared/input-date-range.tsx
+++ b/src/components/shared/input-date-range.tsx
@@ -37,7 +37,8 @@ const Wrapper = styled.div`
     color: #022b54aa;
   }
   .mantine-DatePickerInput-input {
-    background-color: white;
+    color: transparent;
+    background-color: transparent;
   }
   .mantine-DatePickerInput-day {
     color: #022b54;

--- a/src/components/shared/input-select.tsx
+++ b/src/components/shared/input-select.tsx
@@ -34,13 +34,21 @@ const Wrapper = styled.div`
       background-color: #53c3d0;
     }
   }
+  .mantine-Select-input {
+    color: transparent;
+    background-color: transparent;
+  }
   .mantine-Select-rightSection {
     svg {
       display: none;
     }
-    background: no-repeat center 70%;
+    width: 30px;
+    background: no-repeat 30% 70%;
     background-image: url(/icons/arrow-bottom.svg);
     background-size: 16px;
     opacity: 0.3;
+  }
+  [aria-expanded='true'] .mantine-Select-rightSection {
+    transform: scale(1, -1) translate(0, -10px);
   }
 `

--- a/src/components/shared/input-text.tsx
+++ b/src/components/shared/input-text.tsx
@@ -27,7 +27,8 @@ const Wrapper = styled.div`
   &.disabled {
     cursor: not-allowed;
     input {
-      background-color: white;
+      color: transparent;
+      background-color: transparent;
     }
   }
   .mantine-Select-item {

--- a/src/hooks/homes-api.ts
+++ b/src/hooks/homes-api.ts
@@ -4,6 +4,7 @@ import type { Home } from '~/graphql'
 import { useRegionsAPI } from './regions-api'
 
 const DEFAULT_GUESTS = 2
+const DEFAULT_ORDER = 'RELEVANCE'
 const DEFAULT_PAGE = 1
 const PAGE_SIZE = 10
 const PLACEHOLDERS_EMPTY_HOMES = [1, 2, 3].map((i) => ({ id: i }))
@@ -25,7 +26,7 @@ export const useHomesAPI = ({ regionName, period, guests, order }: Props) => {
       region: region?.id ?? '',
       period: period ?? { checkIn: '', checkOut: '' },
       guests: guests ? parseInt('' + guests) : DEFAULT_GUESTS,
-      order: order,
+      order: order ?? DEFAULT_ORDER,
       page: DEFAULT_PAGE,
       pageSize: PAGE_SIZE,
     },

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,0 +1,24 @@
+import { formatRangePeriod } from './date'
+
+describe(formatRangePeriod, () => {
+  it('returns `MMM DD, YYYY - MMM DD, YYYY` when months and years are distinct', () => {
+    const start = '2020-12-23'
+    const end = '2021-01-03'
+    const output = formatRangePeriod(start, end)
+    expect(output).toBe('Dec 23, 2020 - Jan 03, 2021')
+  })
+
+  it('returns `MMM DD - DD, YYYY` when the dates share the same month and year', () => {
+    const start = '2021-01-12'
+    const end = '2021-01-23'
+    const output = formatRangePeriod(start, end)
+    expect(output).toBe('Jan 12 - 23, 2021')
+  })
+
+  it('returns `MMM DD - MMM DD, YYYY` when the dates share only the year', () => {
+    const start = '2021-01-29'
+    const end = '2021-02-05'
+    const output = formatRangePeriod(start, end)
+    expect(output).toBe('Jan 29 - Feb 05, 2021')
+  })
+})

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -9,3 +9,17 @@ export function convertToSQLDate(value: Date) {
   const date = dayjs(value)
   return date.format('YYYY-MM-DD')
 }
+
+export function formatRangePeriod(start: Date | string, end: Date | string) {
+  const dateA = dayjs(start)
+  const dateB = dayjs(end)
+  const sameMonth = dateA.month() === dateB.month()
+  const sameYear = dateA.year() === dateB.year()
+  if (sameYear && sameMonth) {
+    return dateA.format('MMM DD') + ' - ' + dateB.format('DD, YYYY')
+  }
+  if (sameYear) {
+    return dateA.format('MMM DD') + ' - ' + dateB.format('MMM DD, YYYY')
+  }
+  return dateA.format('MMM DD, YYYY') + ' - ' + dateB.format('MMM DD, YYYY')
+}


### PR DESCRIPTION
Improved a few styles in the `app-header` and introduced a fade-in animation component for the `not-found-home` page.

Closes #24 